### PR TITLE
correct dependency to snakemake

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,11 @@
 """The setup script."""
 
 from setuptools import setup, find_packages
+import sys
+
+if sys.version_info < (3, 5):
+    print("At least Python 3.5 is required.\n", file=sys.stderr)
+    exit(1)
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
@@ -15,8 +20,7 @@ requirements = [
     'Click>=6.0',
     'click-log',
     'PyYAML>=4.2b1',
-    'snakemake>=3.13.2',
-    # TODO: put package requirements here
+    'snakemake>=5.5.1',
 ]
 
 setup_requirements = [
@@ -54,12 +58,6 @@ setup(
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
     test_suite='tests',

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, flake8
+envlist = py35, flake8
+# py26, py27, py33, py3i4
 
 [travis]
 python =
     3.5: py35
-    3.4: py34
-    3.3: py33
-    2.7: py27
-    2.6: py26
+#    3.4: py34
+#    3.3: py33
+#    2.7: py27
+#    2.6: py26
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
Since the SNAKEFILE_CHOICES variable is used we have to depend on snakemake>=5.5.1

```
pip install wbuild snakemake
Requirement already satisfied: wbuild in /home/mertes/miniconda3/lib/python3.6/site-packages (1.6.4)
Requirement already satisfied: snakemake in /home/mertes/miniconda3/lib/python3.6/site-packages (3.13.3)
Requirement already satisfied: click-log in /home/mertes/miniconda3/lib/python3.6/site-packages (from wbuild) (0.3.2)
Requirement already satisfied: PyYAML>=4.2b1 in /home/mertes/miniconda3/lib/python3.6/site-packages (from wbuild) (5.1)
Requirement already satisfied: Click>=6.0 in /home/mertes/miniconda3/lib/python3.6/site-packages (from wbuild) (7.0)
Requirement already satisfied: wrapt in /home/mertes/miniconda3/lib/python3.6/site-packages (from snakemake) (1.11.1)
Requirement already satisfied: requests in /home/mertes/miniconda3/lib/python3.6/site-packages (from snakemake) (2.21.0)Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /home/mertes/miniconda3/lib/python3.6/site-packages (from requests->snakemake) (3.0.4)
Requirement already satisfied: urllib3<1.25,>=1.21.1 in /home/mertes/miniconda3/lib/python3.6/site-packages (from requests->snakemake) (1.24.2)
Requirement already satisfied: idna<2.9,>=2.5 in /home/mertes/miniconda3/lib/python3.6/site-packages (from requests->snakemake) (2.8)
Requirement already satisfied: certifi>=2017.4.17 in /home/mertes/miniconda3/lib/python3.6/site-packages (from requests->snakemake) (2019.3.9)
(base) mertes@DESKTOP-MB70GOB:~/projects/FraseR-analysis$ wbuild update
Traceback (most recent call last):
  File "/home/mertes/miniconda3/bin/wbuild", line 6, in <module>
    from wbuild.cli import main
  File "/home/mertes/miniconda3/lib/python3.6/site-packages/wbuild/__init__.py", line 10, in <module>
    from . import autolink
  File "/home/mertes/miniconda3/lib/python3.6/site-packages/wbuild/autolink.py", line 6, in <module>
    from wbuild.utils import Config
  File "/home/mertes/miniconda3/lib/python3.6/site-packages/wbuild/utils.py", line 12, in <module>
    from snakemake import get_argument_parser, parse_config, SNAKEFILE_CHOICES
ImportError: cannot import name 'SNAKEFILE_CHOICES'
```