### PR TITLE
fix path if list

### DIFF
--- a/wbuild/utils.py
+++ b/wbuild/utils.py
@@ -275,6 +275,10 @@ class Config:
                     self.path = p
                     break
         else:
+            if type(self.path) is list:
+                if len(self.path) != 1:
+                    raise Exception("Path is a list of more than one element! '" + str(self.path) + "'")
+                self.path = self.path[0]
             self.path=os.path.abspath(self.path)
 
         # this is taken from the snakemake main file


### PR DESCRIPTION
In drop on docker I get following error:

I guess it is due to how we call internally a snakemake submodule. But not sure where it comes from @kTakumo @mumichae @vyepez88 At least this commit fixes my problem.

```
TypeError in line 7 of /usr/local/envs/drop-docker/lib/python3.7/site-packages/wbuild/wBuild.snakefile:
expected str, bytes or os.PathLike object, not list
  File "/drop/.drop/modules/aberrant-expression-pipeline/Snakefile", line 13, in <module>
  File "/usr/local/envs/drop-docker/lib/python3.7/site-packages/wbuild/wBuild.snakefile", line 7, in <module>
  File "/usr/local/envs/drop-docker/lib/python3.7/site-packages/wbuild/scanFiles.py", line 45, in writeDependencyFile
  File "/usr/local/envs/drop-docker/lib/python3.7/site-packages/wbuild/utils.py", line 278, in __init__
  File "/usr/local/envs/drop-docker/lib/python3.7/posixpath.py", line 378, in abspath
Shutting down, this might take some time.
Exiting because a job execution failed. Look above for error message
Complete log: /drop/.drop/modules/aberrant-expression-pipeline/.snakemake/log/2020-06-02T054049.845792.snakemake.log
```