### PR TITLE
use `sed` to remove outputs before `dot` command

### DIFF
--- a/wbuild/demo/Snakefile
+++ b/wbuild/demo/Snakefile
@@ -27,4 +27,4 @@ rule subIndex:
         graph = graph_file
     run:
         ci(subdir, index_name)
-        shell("snakemake --rulegraph {output.index} | dot -Tsvg -Grankdir=LR > {output.graph}")
+        shell("snakemake --rulegraph {output.index} | sed -ne '/digraph snakemake_dag/,/}}/p' | dot -Tsvg -Grankdir=LR > {output.graph}")

--- a/wbuild/wBuild.snakefile
+++ b/wbuild/wBuild.snakefile
@@ -36,13 +36,13 @@ rule graph_single:
     output: htmlOutputPath + "/{subindex}_dep.{ext}"
     shell:
         """
-        snakemake --rulegraph {input} | dot -T{wildcards.ext} -Grankdir=LR > {output}
+        snakemake --rulegraph {input} | sed -ne '/digraph snakemake_dag/,/}}/p' | dot -T{wildcards.ext} -Grankdir=LR > {output}
         """
 
 # obsolete
 rule graph:
     input: config["htmlOutputPath"] + "/dep.svg"
-    #shell: "snakemake --rulegraph | dot -Tsvg -Grankdir=LR > {output}"
+    #shell: "snakemake --rulegraph | sed -ne '/digraph snakemake_dag/,/}}/p' | dot -Tsvg -Grankdir=LR > {output}"
 
 rule clean:
     shell: "rm -Rf {config[htmlOutputPath]}* .wBuild/__pycache__"


### PR DESCRIPTION
- Fixes the problem explained at: https://github.com/gagneurlab/drop/pull/200
- The issue: "Dependency graph fails, as soon as any output is printed to standard out beforehand. This pull request filers the rulegraph output, so that prior output doesn't mess up the graph generation." 
- The same solution explained https://github.com/gagneurlab/drop/pull/200#pullrequestreview-673897181 is implemented at this pull request.